### PR TITLE
fix(coverage): Make BruteForceSequenceMatcher only look at first path

### DIFF
--- a/src/main/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcher.scala
+++ b/src/main/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcher.scala
@@ -70,8 +70,10 @@ class BruteForceSequenceMatcher(baseDir: File, sourcePath: String) extends PathS
   // mock able helpers that allow us to remove the dependency to the real file system during tests
 
   private[pathcleaner] def initSourceDir(): File = {
-    val sourceDir = new File(baseDir, sourcePath)
-    sourceDir
+    sourcePath.split(",").headOption.map { first =>
+      val sourceDir = new File(baseDir, first)
+      sourceDir
+    }.getOrElse(null)
   }
 
   private[pathcleaner] def initFilesMap(): Map[String, Seq[PathSeq]] = {


### PR DESCRIPTION
Currently `BruteForceSequenceMatcher` doesn't handle multiple comma-delimited sources provided in `sonar.sources`. One might specify multiple comma-delimited source paths via `sonar.sources` in order to analyze both Scala and JavaScript, for example.

This hack doesn't fix the root issue but makes the behavior a little more straightforward, as right now it just treats a list of paths as a single path.