### PR TITLE
fix(coverage): i hope this provides help for ppl use a project structure such as mine

### DIFF
--- a/src/main/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcher.scala
+++ b/src/main/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcher.scala
@@ -20,11 +20,15 @@
 package com.buransky.plugins.scoverage.pathcleaner
 
 import java.io.File
+
 import org.apache.commons.io.FileUtils
 import BruteForceSequenceMatcher._
 import com.buransky.plugins.scoverage.util.PathUtil
+
 import scala.collection.JavaConversions._
 import org.sonar.api.utils.log.Loggers
+
+import scala.annotation.tailrec
 
 object BruteForceSequenceMatcher {
 
@@ -48,38 +52,54 @@ object BruteForceSequenceMatcher {
   */
 class BruteForceSequenceMatcher(baseDir: File, sourcePath: String) extends PathSanitizer {
 
-  private val sourceDir = initSourceDir()
-  require(sourceDir.isAbsolute)
-  require(sourceDir.isDirectory)
+  private val sourceDirs = initSourceDir()
 
   private val log = Loggers.get(classOf[BruteForceSequenceMatcher])
-  private val sourcePathLength = PathUtil.splitPath(sourceDir.getAbsolutePath).size
+  //private val sourcePathLength =
   private val filesMap = initFilesMap()
 
 
   def getSourceRelativePath(reportPath: PathSeq): Option[PathSeq] = {
-    // match with file system map of files
-    val relPathOption = for {
-      absPathCandidates <- filesMap.get(reportPath.last)
-      path <- absPathCandidates.find(absPath => absPath.endsWith(reportPath))
-    } yield path.drop(sourcePathLength)
+    getSourceRelativePathInner(filesMap, reportPath)
+  }
 
-    relPathOption
+  @tailrec
+  final def getSourceRelativePathInner(elements:Seq[(Int, Map[String, Seq[PathSeq]])], reportPath: PathSeq): Option[PathSeq]= {
+    elements match {
+      case Nil => None
+      case (sourcePathLength, head) :: rest =>
+        val relPathOption = for {
+          absPathCandidates <- head.get(reportPath.last)
+          path <- absPathCandidates.find(absPath => absPath.endsWith(reportPath))
+        } yield {
+          path.drop(sourcePathLength)
+        }
+        relPathOption match {
+          case None => getSourceRelativePathInner(rest, reportPath)
+          case v => v
+        }
+    }
   }
 
   // mock able helpers that allow us to remove the dependency to the real file system during tests
 
-  private[pathcleaner] def initSourceDir(): File = {
-    val sourceDir = new File(baseDir, sourcePath)
-    sourceDir
+  private[pathcleaner] def initSourceDir(): Seq[File] = {
+    sourcePath.split(",").map { first =>
+      println(first)
+      val sourceDir = new File(baseDir, first)
+      require(sourceDir.isAbsolute)
+      require(sourceDir.isDirectory)
+      sourceDir
+    }
   }
 
-  private[pathcleaner] def initFilesMap(): Map[String, Seq[PathSeq]] = {
-    val srcFiles = FileUtils.iterateFiles(sourceDir, extensions, true)
-    val paths = srcFiles.map(file => PathUtil.splitPath(file.getAbsolutePath)).toSeq
-
-    // group them by filename, in case multiple files have the same name
-    paths.groupBy(path => path.last)
+  private[pathcleaner] def initFilesMap(): Seq[(Int, Map[String, Seq[PathSeq]])] = {
+    sourceDirs.map { sourceDir =>
+      val srcFiles = FileUtils.iterateFiles(sourceDir, extensions, true)
+      val paths = srcFiles.map(file => PathUtil.splitPath(file.getAbsolutePath)).toSeq
+      // group them by filename, in case multiple files have the same name
+      (PathUtil.splitPath(sourceDir.getAbsolutePath).size, paths.groupBy(path => path.last))
+    }
   }
 
 }

--- a/src/main/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcher.scala
+++ b/src/main/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcher.scala
@@ -68,8 +68,6 @@ class BruteForceSequenceMatcher(baseDir: File, sourcePath: String) extends PathS
     elements match {
       case Nil => None
       case (sourcePathLength, head) :: rest =>
-        println(head)
-        println(rest)
         val relPathOption = for {
           absPathCandidates <- head.get(reportPath.last)
           path <- absPathCandidates.find(absPath => absPath.endsWith(reportPath))

--- a/src/main/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcher.scala
+++ b/src/main/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcher.scala
@@ -68,6 +68,8 @@ class BruteForceSequenceMatcher(baseDir: File, sourcePath: String) extends PathS
     elements match {
       case Nil => None
       case (sourcePathLength, head) :: rest =>
+        println(head)
+        println(rest)
         val relPathOption = for {
           absPathCandidates <- head.get(reportPath.last)
           path <- absPathCandidates.find(absPath => absPath.endsWith(reportPath))

--- a/src/main/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcher.scala
+++ b/src/main/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcher.scala
@@ -85,7 +85,6 @@ class BruteForceSequenceMatcher(baseDir: File, sourcePath: String) extends PathS
 
   private[pathcleaner] def initSourceDir(): Seq[File] = {
     sourcePath.split(",").map { first =>
-      println(first)
       val sourceDir = new File(baseDir, first)
       require(sourceDir.isAbsolute)
       require(sourceDir.isDirectory)
@@ -93,13 +92,13 @@ class BruteForceSequenceMatcher(baseDir: File, sourcePath: String) extends PathS
     }
   }
 
-  private[pathcleaner] def initFilesMap(): Seq[(Int, Map[String, Seq[PathSeq]])] = {
+  private[pathcleaner] def initFilesMap(): List[(Int, Map[String, Seq[PathSeq]])] = {
     sourceDirs.map { sourceDir =>
       val srcFiles = FileUtils.iterateFiles(sourceDir, extensions, true)
       val paths = srcFiles.map(file => PathUtil.splitPath(file.getAbsolutePath)).toSeq
       // group them by filename, in case multiple files have the same name
       (PathUtil.splitPath(sourceDir.getAbsolutePath).size, paths.groupBy(path => path.last))
-    }
+    }.toList
   }
 
 }

--- a/src/test/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcherSpec.scala
+++ b/src/test/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcherSpec.scala
@@ -114,6 +114,6 @@ class BruteForceSequenceMatcherSpec extends FlatSpec with Matchers with MockitoS
     }
 
     override private[pathcleaner] def initSourceDir(): Seq[File] = List(srcDir)
-    override private[pathcleaner] def initFilesMap(): Seq[(Int, Map[String, Seq[PathSeq]])] = List((PathUtil.splitPath(srcDir.getAbsolutePath).size, filesMap))
+    override private[pathcleaner] def initFilesMap(): List[(Int, Map[String, Seq[PathSeq]])] = List((PathUtil.splitPath(srcDir.getAbsolutePath).size, filesMap))
   }
 }

--- a/src/test/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcherSpec.scala
+++ b/src/test/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcherSpec.scala
@@ -26,6 +26,8 @@ import org.scalatest.FlatSpec
 import com.buransky.plugins.scoverage.pathcleaner.BruteForceSequenceMatcher.PathSeq
 import org.scalatest.Matchers
 import java.io.File
+
+import com.buransky.plugins.scoverage.util.PathUtil
 import org.mockito.Mockito._
 
 @RunWith(classOf[JUnitRunner])
@@ -111,7 +113,7 @@ class BruteForceSequenceMatcherSpec extends FlatSpec with Matchers with MockitoS
       dir
     }
 
-    override private[pathcleaner] def initSourceDir(): File = srcDir
-    override private[pathcleaner] def initFilesMap(): Map[String, Seq[PathSeq]] = filesMap
+    override private[pathcleaner] def initSourceDir(): Seq[File] = List(srcDir)
+    override private[pathcleaner] def initFilesMap(): Seq[(Int, Map[String, Seq[PathSeq]])] = List((PathUtil.splitPath(srcDir.getAbsolutePath).size, filesMap))
   }
 }


### PR DESCRIPTION
when the sonar.sources has comma delimited paths, i cant get coverage reports into sonar.

i do not like my additions but have not spent the time to full understand how ScoverageSensor.scala my work if it works with absolute paths generated by BruteForceSequenceMatch.scala.

again, its as hacky as it can get, and im ashamed, but the previous merge was still not helping me very much.