### PR TITLE
Add collection of Scala methods and classes

### DIFF
--- a/src/main/scala/com/sagacify/sonar/scala/Measures.scala
+++ b/src/main/scala/com/sagacify/sonar/scala/Measures.scala
@@ -1,16 +1,19 @@
 package com.sagacify.sonar.scala
 
 import scala.annotation.tailrec
-
 import scalariform.lexer.ScalaLexer
 import scalariform.lexer.Token
-import scalariform.lexer.Tokens.LINE_COMMENT
-import scalariform.lexer.Tokens.MULTILINE_COMMENT
-import scalariform.lexer.Tokens.XML_COMMENT
-import scalariform.lexer.Tokens.WS
-import scalariform.lexer.Tokens.EOF
+import scalariform.lexer.Tokens._
 
 object Measures {
+
+  final def count_classes(tokens: List[Token], i: Int = 0): Int = {
+    var count = 0
+    tokens.foreach(token => if (token.tokenType == CLASS || token.tokenType == OBJECT) count += 1)
+
+    count
+  }
+
 
   /* applied on raw source code */
 

--- a/src/main/scala/com/sagacify/sonar/scala/Measures.scala
+++ b/src/main/scala/com/sagacify/sonar/scala/Measures.scala
@@ -6,14 +6,19 @@ import scalariform.lexer.Token
 import scalariform.lexer.Tokens._
 
 object Measures {
-
-  final def count_classes(tokens: List[Token], i: Int = 0): Int = {
+  def count_classes(tokens: List[Token]): Int = {
     var count = 0
     tokens.foreach(token => if (token.tokenType == CLASS || token.tokenType == OBJECT) count += 1)
 
     count
   }
 
+  final def count_methods(tokens: List[Token]): Int = {
+    var count = 0
+    tokens.foreach(token => if (token.tokenType == DEF) count += 1)
+
+    count
+  }
 
   /* applied on raw source code */
 

--- a/src/main/scala/com/sagacify/sonar/scala/ScalaSensor.scala
+++ b/src/main/scala/com/sagacify/sonar/scala/ScalaSensor.scala
@@ -36,7 +36,7 @@ class ScalaSensor(scala: Scala, fs: FileSystem) extends Sensor {
                           CM.NCLOC,
                           Measures.count_ncloc(tokens))
 
-      // context.saveMeasure(input, CM.CLASSES, classes)
+      context.saveMeasure(inputFile, CM.CLASSES, Measures.count_classes(tokens))
       // context.saveMeasure(input, CM.FUNCTIONS, methods)
       // context.saveMeasure(input, CM.ACCESSORS, accessors)
       // context.saveMeasure(input, CM.COMPLEXITY_IN_FUNCTIONS, complexityInMethods)

--- a/src/main/scala/com/sagacify/sonar/scala/ScalaSensor.scala
+++ b/src/main/scala/com/sagacify/sonar/scala/ScalaSensor.scala
@@ -29,22 +29,18 @@ class ScalaSensor(scala: Scala, fs: FileSystem) extends Sensor {
       val sourceCode = Source.fromFile(inputFile.file, charset).mkString
       val tokens = Scala.tokenize(sourceCode, version)
 
-      context.saveMeasure(inputFile,
-                          CM.COMMENT_LINES,
-                          Measures.count_comment_lines(tokens))
-      context.saveMeasure(inputFile,
-                          CM.NCLOC,
-                          Measures.count_ncloc(tokens))
-
+      context.saveMeasure(inputFile, CM.COMMENT_LINES, Measures.count_comment_lines(tokens))
+      context.saveMeasure(inputFile, CM.NCLOC, Measures.count_ncloc(tokens))
       context.saveMeasure(inputFile, CM.CLASSES, Measures.count_classes(tokens))
-      // context.saveMeasure(input, CM.FUNCTIONS, methods)
-      // context.saveMeasure(input, CM.ACCESSORS, accessors)
-      // context.saveMeasure(input, CM.COMPLEXITY_IN_FUNCTIONS, complexityInMethods)
-      // context.saveMeasure(input, CM.COMPLEXITY_IN_CLASSES, fileComplexity)
-      // context.saveMeasure(input, CM.COMPLEXITY, fileComplexity)
-      // context.saveMeasure(input, CM.PUBLIC_API, publicApiChecker.getPublicApi())
-      // context.saveMeasure(input, CM.PUBLIC_DOCUMENTED_API_DENSITY, publicApiChecker.getDocumentedPublicApiDensity())
-      // context.saveMeasure(input, CM.PUBLIC_UNDOCUMENTED_API, publicApiChecker.getUndocumentedPublicApi())
+      context.saveMeasure(inputFile, CM.FUNCTIONS, Measures.count_methods(tokens))
+
+      // context.saveMeasure(inputFile, CM.ACCESSORS, accessors)
+      // context.saveMeasure(inputFile, CM.COMPLEXITY_IN_FUNCTIONS, complexityInMethods)
+      // context.saveMeasure(inputFile, CM.COMPLEXITY_IN_CLASSES, fileComplexity)
+      // context.saveMeasure(inputFile, CM.COMPLEXITY, fileComplexity)
+      // context.saveMeasure(inputFile, CM.PUBLIC_API, publicApiChecker.getPublicApi())
+      // context.saveMeasure(inputFile, CM.PUBLIC_DOCUMENTED_API_DENSITY, publicApiChecker.getDocumentedPublicApiDensity())
+      // context.saveMeasure(inputFile, CM.PUBLIC_UNDOCUMENTED_API, publicApiChecker.getUndocumentedPublicApi())
 
     }
   }

--- a/src/test/resources/ScalaFile2.scala
+++ b/src/test/resources/ScalaFile2.scala
@@ -7,3 +7,6 @@ class ScalaFile2 {
     println("function called.")
   }
 }
+
+object ScalaFile2 {
+}

--- a/src/test/resources/ScalaFile2.scala
+++ b/src/test/resources/ScalaFile2.scala
@@ -9,4 +9,5 @@ class ScalaFile2 {
 }
 
 object ScalaFile2 {
+  def func2 = ""
 }

--- a/src/test/scala/com/sagacify/sonar/scala/BaseMetricSensorSpec.scala
+++ b/src/test/scala/com/sagacify/sonar/scala/BaseMetricSensorSpec.scala
@@ -67,6 +67,8 @@ class ScalaSensorSpec extends FlatSpec with Matchers {
           .saveMeasure(file, CM.FILES, 1)
       verify(sensorContext, times(1))
           .saveMeasure(file, CM.COMMENT_LINES, 0)
+      verify(sensorContext, times(1))
+          .saveMeasure(file, CM.CLASSES, 1)
 
     }
   }
@@ -87,7 +89,8 @@ class ScalaSensorSpec extends FlatSpec with Matchers {
           .saveMeasure(file, CM.FILES, 1)
       verify(sensorContext, times(1))
           .saveMeasure(file, CM.COMMENT_LINES, 1)
-
+      verify(sensorContext, times(1))
+        .saveMeasure(file, CM.CLASSES, 2)
     }
   }
 }

--- a/src/test/scala/com/sagacify/sonar/scala/BaseMetricSensorSpec.scala
+++ b/src/test/scala/com/sagacify/sonar/scala/BaseMetricSensorSpec.scala
@@ -69,6 +69,8 @@ class ScalaSensorSpec extends FlatSpec with Matchers {
           .saveMeasure(file, CM.COMMENT_LINES, 0)
       verify(sensorContext, times(1))
           .saveMeasure(file, CM.CLASSES, 1)
+      verify(sensorContext, times(1))
+        .saveMeasure(file, CM.FUNCTIONS, 1)
 
     }
   }
@@ -91,6 +93,8 @@ class ScalaSensorSpec extends FlatSpec with Matchers {
           .saveMeasure(file, CM.COMMENT_LINES, 1)
       verify(sensorContext, times(1))
         .saveMeasure(file, CM.CLASSES, 2)
+      verify(sensorContext, times(1))
+        .saveMeasure(file, CM.FUNCTIONS, 2)
     }
   }
 }


### PR DESCRIPTION
I needed Sonar to be able to collect Scala classes and method and that's why I extended the code in a way that the author intended. 
Btw I count both "object" and "class" for classes.
I run several test on my local SonarQube and both of the methods worked OK.