### PR TITLE
Fix for the absolute paths issue in the original `sonar-scoverage-plugin`

### DIFF
--- a/samples/maven/combined-scala-java-multi-module-sonar/pom.xml
+++ b/samples/maven/combined-scala-java-multi-module-sonar/pom.xml
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>org.scoverage</groupId>
                 <artifactId>scoverage-maven-plugin</artifactId>
-                <version>1.0.4</version>
+                <version>1.3.0</version>
                 <configuration>
                     <highlighting>true</highlighting>
                 </configuration>

--- a/samples/maven/combined-scala-java-sonar/pom.xml
+++ b/samples/maven/combined-scala-java-sonar/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.scoverage</groupId>
                 <artifactId>scoverage-maven-plugin</artifactId>
-                <version>1.0.4</version>
+                <version>1.3.0</version>
                 <configuration>
                     <highlighting>true</highlighting>
                 </configuration>

--- a/src/main/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcher.scala
+++ b/src/main/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcher.scala
@@ -71,9 +71,14 @@ class BruteForceSequenceMatcher(baseDir: File, sourcePath: String) extends PathS
 
   private[pathcleaner] def initSourceDir(): File = {
     sourcePath.split(",").headOption.map { first =>
-      val sourceDir = new File(baseDir, first)
-      sourceDir
-    }.getOrElse(null)
+      val firstFile = new File(first)
+      if (firstFile.isAbsolute) {
+        firstFile
+      } else {
+        val sourceDir = new File(baseDir, first)
+        sourceDir
+      }
+    }.orNull
   }
 
   private[pathcleaner] def initFilesMap(): Map[String, Seq[PathSeq]] = {

--- a/src/main/scala/com/buransky/plugins/scoverage/sensor/ScoverageSensor.scala
+++ b/src/main/scala/com/buransky/plugins/scoverage/sensor/ScoverageSensor.scala
@@ -19,6 +19,8 @@
  */
 package com.buransky.plugins.scoverage.sensor
 
+import java.io.File
+
 import com.buransky.plugins.scoverage.language.Scala
 import com.buransky.plugins.scoverage.measure.ScalaMetrics
 import com.buransky.plugins.scoverage.pathcleaner.{BruteForceSequenceMatcher, PathSanitizer}
@@ -183,8 +185,9 @@ class ScoverageSensor(settings: Settings, pathResolver: PathResolver, fileSystem
     
     val inputOption: Option[InputPath] = if (isFile) {
       val p = fileSystem.predicates()
+      val pathPreducate = if (new File(path).isAbsolute) p.hasAbsolutePath(path) else p.hasRelativePath(path)
       Option(fileSystem.inputFile(p.and(
-        p.hasRelativePath(path),
+        pathPreducate,
         p.hasLanguage(Scala.key),
         p.hasType(InputFile.Type.MAIN))))
     } else {

--- a/src/main/scala/com/buransky/plugins/scoverage/sensor/ScoverageSensor.scala
+++ b/src/main/scala/com/buransky/plugins/scoverage/sensor/ScoverageSensor.scala
@@ -185,9 +185,9 @@ class ScoverageSensor(settings: Settings, pathResolver: PathResolver, fileSystem
     
     val inputOption: Option[InputPath] = if (isFile) {
       val p = fileSystem.predicates()
-      val pathPreducate = if (new File(path).isAbsolute) p.hasAbsolutePath(path) else p.hasRelativePath(path)
+      val pathPredicate = if (new File(path).isAbsolute) p.hasAbsolutePath(path) else p.hasRelativePath(path)
       Option(fileSystem.inputFile(p.and(
-        pathPreducate,
+        pathPredicate,
         p.hasLanguage(Scala.key),
         p.hasType(InputFile.Type.MAIN))))
     } else {


### PR DESCRIPTION
The issue was filed [here.](https://github.com/RadoBuransky/sonar-scoverage-plugin/issues/29)
Looks like it's Windows-specific, as I only encountered that on Windows machine.

The original code didn't account for absolute paths, so I added specific checks.
