### PR TITLE
version(sonar): bumping sonar version to 5.6 (lts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Sonarqube plugin for scala analysis
 
 # Set-up
-Intended for sonarqube 5.4
+Intended for sonarqube 5.6
 
 Download the latest relase into your sonar extentions/downloads folder.
 Restart sonarqube either using the update center or manually.

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>sonar-scala-plugin</artifactId>
   <packaging>sonar-plugin</packaging>
-  <version>0.0.3-SNAPSHOT</version>
+  <version>0.0.4-SNAPSHOT</version>
 
   <name>Sonar Scala Plugin</name>
   <description>Enables analysis of Scala projects into Sonar.</description>
@@ -51,7 +51,7 @@
   </issueManagement>
 
   <properties>
-    <sonar.version>5.4</sonar.version>
+    <sonar.version>5.6</sonar.version>
     <sonar.pluginKey>scala</sonar.pluginKey>
     <sonar.pluginName>Scala</sonar.pluginName>
     <sonar.pluginClass>com.sagacify.sonar.scala.ScalaPlugin</sonar.pluginClass>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 # Required metadata
 sonar.projectName=Sonar Scala Plugin
-sonar.projectVersion=0.0.3
+sonar.projectVersion=0.0.4
 
 # Comma-separated paths to directories with sources (required)
 sonar.sources=src


### PR DESCRIPTION
**Problem:**
Version 5.4 is unsupported by most of the plugin maintainers. If you run SonarQube 5.4 just to be able to use sonar-scala 0.0.3, the installation requires you to manually install older versions of other plugins that now support 5.6 only. 

**Solution:**
Upgrading to support v6.x is not easy, as API has changed a lot. Updating to support SonarQube v5.6 LTS, however, is possible with no hassle, and it would make it possible to install/update latest versions of other plugins through SonarQube's web interface and make users' lives easier.

**Proposed change:**
Only bumping `sonar.version` to 5.6, no API changes.